### PR TITLE
Rename environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ To access the data stored inside your database, you need the Turso database url 
 To obtain the database url, run the following command:
 
 ```sh
-export TURSO_DB_URL=$(turso db show the-mugs-store-api --url)
+export TURSO_URL=$(turso db show the-mugs-store-api --url)
 ```
 
 And, to create an authentication token for your database, run:
 
 ```sh
-export TURSO_DB_AUTH_TOKEN=$(turso db tokens create the-mugs-store-api)
+export TURSO_AUTH_TOKEN=$(turso db tokens create the-mugs-store-api)
 ```
 
 ## For local development
@@ -36,8 +36,8 @@ export TURSO_DB_AUTH_TOKEN=$(turso db tokens create the-mugs-store-api)
 Add a `.env` file at the root of the project and inside it add the database url and authentication token for your Turso database obtained in the previous step, these variables will be used to assist in database migration with Drizzle.
 
 ```
-echo "TURSO_DB_URL = $TURSO_DB_URL" > .env
-echo "TURSO_DB_AUTH_TOKEN = $TURSO_DB_AUTH_TOKEN" >> .env
+echo "TURSO_URL = $TURSO_URL" > .env
+echo "TURSO_AUTH_TOKEN = $TURSO_AUTH_TOKEN" >> .env
 ```
 
 Also make the configuration visible to Wrangler:
@@ -85,8 +85,8 @@ npm run start
 Configure the Cloudflare project by running the following commands and copy-pasting the URL and the authentication token when prompted for them:
 
 ```
-wrangler secret put TURSO_DB_URL
-wrangler secret put TURSO_DB_AUTH_TOKEN
+wrangler secret put TURSO_URL
+wrangler secret put TURSO_AUTH_TOKEN
 ```
 
 ## Deployment

--- a/drizzle/migrate.ts
+++ b/drizzle/migrate.ts
@@ -4,8 +4,8 @@ import { drizzle } from 'drizzle-orm/libsql';
 import { migrate } from 'drizzle-orm/libsql/migrator';
 
 const client = createClient({
-  url: process.env.TURSO_DB_URL as string,
-  authToken: process.env.TURSO_DB_AUTH_TOKEN as string,
+  url: process.env.TURSO_URL as string,
+  authToken: process.env.TURSO_AUTH_TOKEN as string,
 });
 
 export const db = drizzle(client);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -19,20 +19,20 @@ import {
 import { eq } from 'drizzle-orm';
 
 interface Env {
-  TURSO_DB_AUTH_TOKEN?: string;
-  TURSO_DB_URL?: string;
+  TURSO_AUTH_TOKEN?: string;
+  TURSO_URL?: string;
   router?: RouterType;
 }
 
 function buildDbClient(env: Env): LibSQLDatabase {
-  const url = env.TURSO_DB_URL?.trim();
+  const url = env.TURSO_URL?.trim();
   if (url === undefined) {
-    throw new Error('TURSO_DB_URL is not defined');
+    throw new Error('TURSO_URL is not defined');
   }
 
-  const authToken = env.TURSO_DB_AUTH_TOKEN?.trim();
+  const authToken = env.TURSO_AUTH_TOKEN?.trim();
   if (authToken === undefined) {
-    throw new Error('TURSO_DB_AUTH_TOKEN is not defined');
+    throw new Error('TURSO_AUTH_TOKEN is not defined');
   }
 
   return drizzle(createClient({ url, authToken }));


### PR DESCRIPTION
Let's use the same environment variable names as Cloudflare integration does by default.